### PR TITLE
add protobuf type hint support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 .eggs/
 __pycache__/
 .pytest_cache/
-
+build
+dist

--- a/pylint_protobuf/__init__.py
+++ b/pylint_protobuf/__init__.py
@@ -96,10 +96,10 @@ class ProtobufDescriptorChecker(BaseChecker):
     name = 'protobuf-descriptor-checker'
 
     def __init__(self, linter):
-        self.linter = linter
         self._seen_imports = None
         self._known_classes = None
         self._known_variables = None
+        BaseChecker.__init__(linter)
 
     def visit_module(self, node):
         self._seen_imports = []
@@ -127,12 +127,16 @@ class ProtobufDescriptorChecker(BaseChecker):
         if not isinstance(node, astroid.Call):
             return  # NOTE: potentially from visit_attribute
         assignment = node.parent
-        if not isinstance(assignment, astroid.Assign):
+        if isinstance(assignment, astroid.Assign):
+            if len(assignment.targets) > 1:
+                # not going to bother with this case
+                return
+            target = assignment.targets[0]
+        elif isinstance(assignment, astroid.AnnAssign):
+            target = assignment.target
+        else:
             return
-        if len(assignment.targets) > 1:
-            # not going to bother with this case
-            return
-        target = assignment.targets[0]
+
         if not isinstance(target, astroid.AssignName):
             return
         func = node.func

--- a/pylint_protobuf/__init__.py
+++ b/pylint_protobuf/__init__.py
@@ -165,7 +165,26 @@ class ProtobufDescriptorChecker(BaseChecker):
         elif obj.name in self._known_variables:
             cls_name = self._known_variables[obj.name]
             cls_fields = self._known_classes[cls_name]
-            if attr.attrname not in cls_fields:
+            if attr.attrname not in cls_fields and attr.attrname not in [
+                "ByteSize",
+                "Clear",
+                "ClearExtension",
+                "ClearField",
+                "CopyFrom",
+                "DESCRIPTOR",
+                "DiscardUnknownFields",
+                "HasExtension",
+                "HasField",
+                "IsInitialized",
+                "ListFields",
+                "MergeFrom",
+                "MergeFromString",
+                "ParseFromString",
+                "SerializePartialToString",
+                "SerializeToString",
+                "SetInParent",
+                "WhichOneof"
+            ]:
                 self.add_message('protobuf-undefined-attribute',
                                  args=(attr.attrname, cls_name), node=attr)
 

--- a/pylint_protobuf/__init__.py
+++ b/pylint_protobuf/__init__.py
@@ -96,10 +96,10 @@ class ProtobufDescriptorChecker(BaseChecker):
     name = 'protobuf-descriptor-checker'
 
     def __init__(self, linter):
+        self.linter = linter
         self._seen_imports = None
         self._known_classes = None
         self._known_variables = None
-        BaseChecker.__init__(linter)
 
     def visit_module(self, node):
         self._seen_imports = []

--- a/setup.py
+++ b/setup.py
@@ -34,4 +34,5 @@ setup(
         'astroid',
         'pylint',
     ],
+    zip_safe=False
 )

--- a/tests/fixture/person.py
+++ b/tests/fixture/person.py
@@ -15,9 +15,10 @@ message Person {
     import subprocess
     subprocess.check_call(['protoc', 'person.proto', '--python_out=.'])
     from person_pb2 import Person
+    from google.protobuf import message as _message
 
 
 def main():
     """A pedantic docstring."""
-    person = Person()
+    person: _message = Person()
     person.should_warn = 123


### PR DESCRIPTION
I add type hint support for google.protobuf.message.Message.  And support some function to avoid no-member or non-attributes errors.