### PR TITLE
Check against protobuf implicit attrs

### DIFF
--- a/pylint_protobuf/__init__.py
+++ b/pylint_protobuf/__init__.py
@@ -12,7 +12,7 @@ MESSAGES = {
         'accessed'
     ),
 }
-PROTOBUF_IMPLICIT_ATTRS = [  # TODO: use these
+PROTOBUF_IMPLICIT_ATTRS = [
     'ByteSize',
     'Clear',
     'ClearExtension',
@@ -168,7 +168,7 @@ def _assignattr(scope, type_fields, node, _):
     if fields is None:
         # assert False, "type fields missing for {!r}".format(expr_type)
         return False, []
-    if attr not in fields:
+    if attr not in fields and attr not in PROTOBUF_IMPLICIT_ATTRS:
         return False, [('protobuf-undefined-attribute', (attr, expr_type), node)]
     return False, []
 


### PR DESCRIPTION
Hello, thanks for this very useful plugin!

This PR makes a small change to allow the plugin to recognise protobuf implicit attrs.