### PR TITLE
Consider wellknowntypes again

### DIFF
--- a/pylint_protobuf/__init__.py
+++ b/pylint_protobuf/__init__.py
@@ -95,8 +95,16 @@ class ProtobufDescriptorChecker(BaseChecker):
                 return self._check_module(val, node)  # FIXME: move
             elif isinstance(val, astroid.ClassDef):
                 cls_def = val
-            if cls_def and getattr(cls_def, '_is_protobuf_class', False):
-                break  # getattr guards against Uninferable (always returns self)
+            if cls_def:
+                if getattr(cls_def, '_is_protobuf_class', False):
+                    break  # getattr guards against Uninferable (always returns self)
+                else:
+                    # Any better way to get this? String parsing seems dirty.
+                    modname, _ = cls_def.instantiate_class().pytype().rsplit('.', 1)
+                    if wellknowntype(modname):
+                        # Disable checks for well known types
+                        self._disable('no-member', node.lineno)
+                        return
         else:
             # couldn't find cls_def
             return


### PR DESCRIPTION
The `test_wellknowntypes` passes, but the feature doesn't actually work:

```
$ cat test.py
"""
Any test
"""
from google.protobuf.any_pb2 import Any

a = Any()
a.Pack()


$ pylint test.py
************* Module test
test.py:7:0: E1101: Instance of 'Any' has no 'Pack' member (no-member)

--------------------------------------------------------------------
Your code has been rated at 0.00/10 (previous run: 10.00/10, -10.00)
```

Looks like nothing checks the `cls_def` for membership in the well known types with the new astroid refactor (which is otherwise great). This PR attempts to rectify that, though I feel like there should be a better way of finding the absolute name/module name a class is defined in...